### PR TITLE
Fix double payment issue, cleanup charging API

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -93,14 +93,14 @@ export default class App {
   }
 
   /**
-   * @deprecated Please use `Mobius.App.charge()` instead."
+   * @deprecated Please use `App.charge()` instead.
    * @param {number} amount - payment amount
    * @param {?string} destination - third party receiver address
    * @returns {StellarSdk.Operation} payment operation
    */
   pay = deprecate((amount, destination = null) => {
     return this.charge(amount, destination);
-  }, "`Mobius.App.pay()` is depreciated, please use `Mobius.App.charge()` instead.");
+  }, "`App.pay()` is deprecated, please use `App.charge()` instead.");
 
   /**
    * Sends money from the application account to the user or third party.

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -93,6 +93,16 @@ export default class App {
   }
 
   /**
+   * @deprecated Please use `Mobius.App.charge()` instead."
+   * @param {number} amount - payment amount
+   * @param {?string} destination - third party receiver address
+   * @returns {StellarSdk.Operation} payment operation
+   */
+  pay = deprecate((amount, destination = null) => {
+    return this.charge(amount, destination);
+  }, "`Mobius.App.pay()` is depreciated, please use `Mobius.App.charge()` instead.");
+
+  /**
    * Sends money from the application account to the user or third party.
    * @param {number} amount - Payment amount
    * @param {string} [destination] - Optional: third party receiver address
@@ -179,7 +189,3 @@ export default class App {
     return true;
   }
 }
-
-App.prototype.pay = deprecate(function pay(amount, destination = null) {
-  return this.charge(amount, destination);
-}, "`Mobius.App.pay()` is depreciated, please use `Mobius.App.charge()` instead.");

--- a/src/utils/deprecate.js
+++ b/src/utils/deprecate.js
@@ -1,7 +1,7 @@
 // Mark that a method should not be used.
 // Returns a modified function which warns once by default.
 // If --no-deprecation is set, then it is a no-op.
-exports.deprecate = function deprecate(fn, msg) {
+export default function deprecate(fn, msg) {
   // Allow for deprecating things in the process of starting up.
   if (global.process === undefined) {
     return function dep(...args) {
@@ -29,4 +29,4 @@ exports.deprecate = function deprecate(fn, msg) {
   }
 
   return deprecated;
-};
+}

--- a/src/utils/deprecate.js
+++ b/src/utils/deprecate.js
@@ -1,0 +1,32 @@
+// Mark that a method should not be used.
+// Returns a modified function which warns once by default.
+// If --no-deprecation is set, then it is a no-op.
+exports.deprecate = function deprecate(fn, msg) {
+  // Allow for deprecating things in the process of starting up.
+  if (global.process === undefined) {
+    return function dep(...args) {
+      return exports.deprecate(fn, msg).apply(this, ...args);
+    };
+  }
+
+  if (process.noDeprecation === true) {
+    return fn;
+  }
+
+  let warned = false;
+  function deprecated(...args) {
+    if (!warned) {
+      if (process.throwDeprecation) {
+        throw new Error(msg);
+      } else if (process.traceDeprecation) {
+        console.trace(msg);
+      } else {
+        console.error(msg);
+      }
+      warned = true;
+    }
+    return fn.apply(this, ...args);
+  }
+
+  return deprecated;
+};

--- a/src/utils/deprecate.js
+++ b/src/utils/deprecate.js
@@ -1,8 +1,14 @@
-// Mark that a method should not be used.
-// Returns a modified function which warns once by default.
-// If --no-deprecation is set, then it is a no-op.
+/**
+ * Mark that a method should not be used.
+ * Returns a modified function which warns once by default.
+ * If `--no-deprecation` flag is set , then it is a no-op.
+ * (see for details https://nodejs.org/docs/latest-v8.x/api/cli.html#cli_no_deprecation)
+ *
+ * @param {function} fn - function or method to deprecate
+ * @param {string} msg - deprecation message
+ * @returns {function}
+ */
 export default function deprecate(fn, msg) {
-  // Allow for deprecating things in the process of starting up.
   if (global.process === undefined) {
     return function dep(...args) {
       return exports.deprecate(fn, msg).apply(this, ...args);
@@ -14,6 +20,7 @@ export default function deprecate(fn, msg) {
   }
 
   let warned = false;
+
   function deprecated(...args) {
     if (!warned) {
       if (process.throwDeprecation) {


### PR DESCRIPTION
- [x] Fix an issue in `Mobius.App.pay()` method which caused double charging
- [x] Rename `Mobius.App.pay()` to more appropriate `Mobius.App.charge()`
- [x] Update `App.transfer()` to follow Ruby SDK behavior
- [x] Introduce `App.payout()` method for `app -> user` payments

New flow:
- `App.charge(amount)` — charge `amount` from user's wallet
- `App.charge(amount, destination)` — charge `amount` from user's wallet, and then immediately transfer it to the third-party
- `App.transfer(amount, destination)` — transfer `amount` from the user wallet to the third-party directly 
- `App.payout(amount)` — payout `amount` to the user
- `App.payout(amount, destination)` — payout `amount` to the third-party